### PR TITLE
Fix mobile navbar layout shift issue

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -110,8 +110,21 @@ All colors MUST be HSL.
     @apply border-border;
   }
 
+  html {
+    overflow-y: scroll;
+    width: 100%;
+  }
+
   body {
     @apply bg-background text-foreground font-sans antialiased;
+    overflow-y: auto !important;
+    padding-right: 0 !important;
+  }
+
+  /* Prevent layout shift when Sheet/Dialog opens */
+  body[data-scroll-locked] {
+    overflow-y: scroll !important;
+    padding-right: 0 !important;
   }
 
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
แก้ปัญหา layout และตัวหนังสือขยับเมื่อเปิด mobile navbar ใน responsive mode

**ปัญหา:**
- เมื่อเปิด mobile navbar (Sheet component) Radix UI จะเพิ่ม overflow:hidden ให้ body
- Scrollbar หายไป ทำให้ content กว้างขึ้นประมาณ 15-17px
- Layout ทั้งหน้าขยับไปด้านขวา สร้างประสบการณ์ที่ไม่ดี

**วิธีแก้:**
- บังคับให้ scrollbar แสดงตลอดเวลาด้วย `overflow-y: scroll` บน html element
- Override การล็อก scroll ของ Radix UI ด้วย !important
- จัดการกับ body[data-scroll-locked] attribute เพื่อรักษา scrollbar
- ป้องกัน padding-right ที่ Radix UI พยายามเพิ่มเข้ามา

**ผลลัพธ์:**
- Mobile navbar เปิด/ปิดได้อย่างลื่นไหล ไม่มีการขยับของ layout
- Scrollbar แสดงอยู่ตลอดเวลา รักษาความกว้างของ viewport
- ปรับปรุง UX บนอุปกรณ์มือถือ