### PR TITLE
fix: Condition map render report

### DIFF
--- a/src/pages/ReportDetail.tsx
+++ b/src/pages/ReportDetail.tsx
@@ -226,14 +226,16 @@ const ReportDetail = () => {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              {report.location_lat && report.location_long ? (
+              {report.location_lat && report.location_long || report.map_link ? (
                 <>
-                  <div>
-                    <p className="text-sm text-muted-foreground">พิกัด</p>
-                    <p className="font-mono text-sm">
-                      {report.location_lat}, {report.location_long}
-                    </p>
-                  </div>
+                  {report.location_lat && report.location_long && (
+                    <div>
+                      <p className="text-sm text-muted-foreground">พิกัด</p>
+                      <p className="font-mono text-sm">
+                        {report.location_lat}, {report.location_long}
+                      </p>
+                    </div>
+                  )}
 
                   {report.map_link && (
                     <Button


### PR DESCRIPTION
จาก issue: https://github.com/winn/thaifloodhelp/issues/29
ผมคิดว่า ถ้าเราทำให้มัน update detail แบบ autonomous มันน่าจะ overkill เกินไป และอาจทำให้ state ไม่ถูกหลักการการ GET ข้อมูล
ผมเลยคิดว่า ถ้ามี map link ก็ให้สามารถ render component ที่จะชี้ไปที่ map ได้เลย โดยไม่ต้องสน lat long
การทำแบบนี้ คิดว่าทำให้ backward compatible ได้ดีกว่า resolve information by itself.

# Compare result

What change

![CleanShot 2025-11-26 at 20 01 14@2x](https://github.com/user-attachments/assets/226769e5-9432-47b6-9359-04fa800c85c2)

เปรียบเทียบกับตัวที่มี data หลังจากถูกป้อนเข้ามาใหม่ หลังจากที่พี่วิน mention https://github.com/winn/thaifloodhelp/issues/29#issuecomment-3579867949

![CleanShot 2025-11-26 at 20 01 38@2x](https://github.com/user-attachments/assets/bd91ba89-529b-41e1-a5a2-8a90833377c8)
