### PR TITLE
ลดการใช้ Token ด้วยการไม่เรียก  ซ้ำ หาก raw_message คงที่

### DIFF
--- a/src/pages/Review.tsx
+++ b/src/pages/Review.tsx
@@ -212,6 +212,7 @@ const Review = () => {
       // Generate embedding for the report (reuse cached if available)
       const embedding =
         existingEmbedding || (await getEmbedding(formData.raw_message))
+      const embeddingString = embedding ? JSON.stringify(embedding) : null
 
       const dataToSave = {
         ...formData,
@@ -224,7 +225,7 @@ const Review = () => {
         location_long: finalLng,
         map_link: finalMapLink,
         last_contact_at: validLastContact,
-        embedding: embedding || null,
+        embedding: embeddingString,
         number_of_patients: formData.number_of_patients || 0,
         number_of_infants: formData.number_of_infants || 0,
         help_categories: formData.help_categories || [],


### PR DESCRIPTION
# Pull Request

จากโค้ดเดิม ใน `pages/Review.tsx`
เมื่อเรียก `proceedWithSave`

มันจะเรียก  checkForDuplicates เพื่อตรวจสอบว่าซ้ำของเดิมไหม
**ปัญหาคือ checkForDuplicates จะทำการ `invoke -> 'generate-embedding'`**

และหากไม่พบว่าซ้ำ ก็จะเรียกต่อที่ `performSave`
และใน `performSave` ก็ทำการ  `invoke -> 'generate-embedding'` ซ้ำอีกครั้ง 
แม้ raw_message จะมีค่าเดิม ไม่เปลี่ยนแปลง

ทำให้เสียเวลา/เครดิตฟังก์ชันซ้ำโดยไม่จำเป็น
---------

แก้ไขด้วยการเพิ่มฟังชั่น `getEmbedding(rawMessage)`
การทำงานคือ มันจะเก็บ raw_message เป็น Key และคู่กับ embedd ไว้ในลักษณะแคช
หากพบ raw_message ซ้ำกัน ก็จะคืนค่าแคช ให้ทันที 

หากไม่ซ้ำ ก็จะ  `invoke -> 'generate-embedding'` 
